### PR TITLE
explicitly specifiy names in pd.MultiIndex

### DIFF
--- a/ecomplexity/proximity.py
+++ b/ecomplexity/proximity.py
@@ -67,7 +67,8 @@ def proximity(data, cols_input, presence_test="rca", val_errors_flag='coerce',
 
         # Reshape as df
         output_index = pd.MultiIndex.from_product([cdata.data_t.index.levels[1],
-                                                   cdata.data_t.index.levels[1]])
+                                                   cdata.data_t.index.levels[1]],
+                                                  names=['prod1','prod2'])
         output = pd.DataFrame(data={'proximity':prox_mat.ravel()},
                               index=output_index)
         output['time'] = t


### PR DESCRIPTION
After upgrading to pandas 1.0+, pd.MultiIndex.from_product tries to infer names, which seems to cause error when running reset_index later. The PR specified names explicitly, fixes cid-harvard/py-ecomplexity#12