### PR TITLE
fix README encoding issue for windows compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
+from pathlib import Path
 from setuptools import setup, find_packages
 
-
 def readme():
-    with open("README.md") as f:
-        return f.read()
+    return Path("README.md").read_text(encoding="utf-8")
 
 setup(name='ecomplexity',
       version='0.5.2',


### PR DESCRIPTION
This PR fixes the README encoding issue by specifying UTF-8 encoding while reading the file.

This ensures compatibility across different platforms, especially Windows environments.